### PR TITLE
Allow specifying output directory

### DIFF
--- a/agents/master_agent.py
+++ b/agents/master_agent.py
@@ -28,10 +28,10 @@ from agents.composer_agent import ComposerAgent
 class MasterAgent:
     """Главный агент системы CodeInspector."""
     
-    def __init__(self, config_path: Optional[str] = None):
+    def __init__(self, config_path: Optional[str] = None, output_dir: Optional[str] = None):
         self.config_path = config_path or "config"
         self.config = self._load_config()
-        self.knowledge_base = KnowledgeBase()
+        self.knowledge_base = KnowledgeBase(output_dir or "output")
         self.language_support = LanguageSupport()
         
         # Создаем планирующего агента

--- a/main.py
+++ b/main.py
@@ -104,7 +104,7 @@ async def main():
         os.chdir(current_dir)
         
         # Создаем мастер-агента
-        master_agent = MasterAgent(config_path=args.config)
+        master_agent = MasterAgent(config_path=args.config, output_dir=args.output)
         
         # Запускаем анализ
         result = await master_agent.analyze_project(args.project_path)
@@ -119,11 +119,11 @@ async def main():
         print(f"📄 Отчет сохранен: {result_file}")
         
         # Показываем дополнительные файлы
-        json_file = Path("knowledge_base.json")
+        json_file = output_dir / "analysis_data.json"
         if json_file.exists():
             print(f"💾 База знаний: {json_file}")
-        
-        markdown_file = Path("project_analysis.md")
+
+        markdown_file = output_dir / "README_ANALYSIS.md"
         if markdown_file.exists():
             print(f"📝 Markdown отчет: {markdown_file}")
         


### PR DESCRIPTION
## Summary
- update `MasterAgent` to pass `output_dir` to `KnowledgeBase`
- propagate the new option to `main.py`
- write analysis results into the provided directory

## Testing
- `pip install -q -r requirements.txt` *(fails: WARNING about running as root)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_68611bf1cb588324aab7eca9e6c94c36